### PR TITLE
Add vanilla Kubernetes manifests for deploying the Timescale exporter resources

### DIFF
--- a/hack/exec-timescale-db.sh
+++ b/hack/exec-timescale-db.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+set -e
+
+: "${KUBECONFIG:?}"
+
+NAMESPACE=${1:-${METERING_NAMESPACE}}
+
+oc --namespace=${NAMESPACE} exec -it $(oc --namespace=${NAMESPACE} get pods -l  app=timescaledb --no-headers | awk '{ print $1 }') -- psql --username=testuser --dbname=metering

--- a/manifests/monitoring/cluster-monitoring-configmap.yaml
+++ b/manifests/monitoring/cluster-monitoring-configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    prometheusK8s:
+      remoteWrite:
+      - url: "http://exporter.tflannag.svc.cluster.local:9201/write"
+        writeRelabelConfigs:
+          - sourceLabels: [__name__]
+            regex: 'metering:(.*)'
+            action: keep

--- a/manifests/monitoring/prom-rules.yaml
+++ b/manifests/monitoring/prom-rules.yaml
@@ -1,0 +1,52 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: metering
+  namespace: tflannag
+spec:
+  groups:
+  - interval: 5s
+    name: metering.rules
+    rules:
+    - expr: |
+        sum(container_memory_usage_bytes{container!="POD", container!="",pod!=""}) by (pod, namespace, node)
+      record: metering:container_memory_usage_bytes
+    - expr: |
+        kube_node_status_allocatable_cpu_cores * on(node) group_left(provider_id) max(kube_node_info) by (node, provider_id)
+      record: metering:node_allocatable_cpu_cores
+    - expr: |
+        kube_node_status_allocatable_memory_bytes * on(node) group_left(provider_id) max(kube_node_info) by (node, provider_id)
+      record: metering:node_allocatable_memory_bytes
+    - expr: |
+        kube_node_status_capacity_cpu_cores * on(node) group_left(provider_id) max(kube_node_info) by (node, provider_id)
+      record: metering:node_capacity_cpu_cores
+    - expr: |
+        kube_node_status_capacity_memory_bytes * on(node) group_left(provider_id) max(kube_node_info) by (node, provider_id)
+      record: metering:node_capacity_memory_bytes
+    - expr: |
+        kubelet_volume_stats_capacity_bytes
+      record: metering:persistentvolumeclaim_capacity_bytes
+    - expr: |
+        kube_persistentvolumeclaim_status_phase
+      record: metering:persistentvolumeclaim_phase
+    - expr: |
+        max(kube_persistentvolumeclaim_resource_requests_storage_bytes) by (namespace, persistentvolumeclaim) + on (namespace, persistentvolumeclaim) group_left(storageclass, volumename) sum(kube_persistentvolumeclaim_info{volumename!=""}) by (namespace, persistentvolumeclaim, storageclass, volumename) * 0
+      record: metering:persistentvolumeclaim_request_bytes
+    - expr: |
+        kubelet_volume_stats_used_bytes
+      record: metering:persistentvolumeclaim_usage_bytes
+    - expr: |
+        sum(kube_pod_container_resource_limits_cpu_cores) by (pod, namespace, node)
+      record: metering:pod_limit_cpu_cores
+    - expr: |
+        sum(kube_pod_container_resource_limits_memory_bytes) by (pod, namespace, node)
+      record: metering:pod_limit_memory_bytes
+    - expr: |
+        kube_pod_spec_volumes_persistentvolumeclaims_info
+      record: metering:pod_persistentvolumeclaim_request_info
+    - expr: |
+        sum(kube_pod_container_resource_requests_cpu_cores) by (pod, namespace, node)
+      record: metering:pod_request_cpu_cores
+    - expr: |
+        sum(kube_pod_container_resource_requests_memory_bytes) by (pod, namespace, node)
+      record: metering:pod_request_memory_bytes

--- a/manifests/timescale/db/deployment.yaml
+++ b/manifests/timescale/db/deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: timescaledb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: timescaledb
+  template:
+    metadata:
+      labels:
+        app: timescaledb
+    spec:
+      securityContext:
+        fsGroup: 70
+        runAsUser: 70
+      containers:
+        - env:
+            - name: POSTGRES_DB
+              value: metering
+            - name: POSTGRES_PASSWORD
+              value: testpass
+            - name: POSTGRES_USER
+              value: testuser
+            - name: POSTGRES_HOST_AUTH_METHOD
+              value: trust
+          image: timescale/timescaledb:latest-pg12
+          imagePullPolicy: IfNotPresent
+          name: postgresql
+          ports:
+            - containerPort: 5432
+              protocol: TCP
+          resources: {}

--- a/manifests/timescale/db/pvc.yaml
+++ b/manifests/timescale/db/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: timescaledb-postgres-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  volumeMode: Filesystem

--- a/manifests/timescale/db/service.yaml
+++ b/manifests/timescale/db/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: timescaledb
+  labels:
+    app: timescaledb
+spec:
+  selector:
+    app: timescaledb
+  ports:
+    - name: 5432-tcp
+      port: 5432
+      protocol: TCP
+      targetPort: 5432
+  type: ClusterIP

--- a/manifests/timescale/db/statefulset.yaml
+++ b/manifests/timescale/db/statefulset.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: timescaledb
+spec:
+  replicas: 1
+  serviceName: timescaledb
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: timescaledb
+  template:
+    metadata:
+      name: timescaledb
+      labels:
+        app: timescaledb
+    spec:
+      securityContext:
+        fsGroup: 1000
+      containers:
+        - name: timescaledb
+          image: timescale/timescaledb:latest-pg12
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9201
+              name: connector-port
+          env:
+            - name: POSTGRES_DB
+              value: metering
+            - name: POSTGRES_PASSWORD
+              value: testpass
+            - name: POSTGRES_USER
+              value: testuser
+            - name: POSTGRES_HOST_AUTH_METHOD
+              value: trust
+          resources:
+            limits:
+              cpu: "1"
+              memory: 500Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          volumeMounts:
+            - name: postgres-lib-data
+              mountPath: /var/lib/postgresql
+      volumes:
+        - name: postgres-lib-data
+          persistentVolumeClaim:
+            claimName: timescaledb-postgres-data

--- a/manifests/timescale/exporter/cronjob.yaml
+++ b/manifests/timescale/exporter/cronjob.yaml
@@ -1,0 +1,31 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: exporter-drop-chunk
+  labels:
+    app: exporter
+spec:
+  schedule: "*/30 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: exporter-drop-chunk
+              image: postgres:12-alpine
+              args:
+                - psql
+                - -c
+                - CALL prom_api.execute_maintenance();
+              env:
+                - name: PGPORT
+                  value: "5432"
+                - name: PGUSER
+                  value: testuser
+                - name: PGPASSWORD
+                  value: testpass
+                - name: PGHOST
+                  value: timescaledb.tflannag.svc.cluster.local
+                - name: PGDATABASE
+                  value: metering
+          restartPolicy: OnFailure

--- a/manifests/timescale/exporter/deployment.yaml
+++ b/manifests/timescale/exporter/deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: exporter
+  labels:
+    app: exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: exporter
+  template:
+    metadata:
+      labels:
+        app: exporter
+    spec:
+      containers:
+        - name: exporter
+          image: timescale/timescale-prometheus
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          ports:
+            - containerPort: 9201
+              name: connector-port
+          env:
+            - name: TS_PROM_DB_PORT
+              value: "5432"
+            - name: TS_PROM_DB_USER
+              value: testuser
+            - name: TS_PROM_DB_PASSWORD
+              value: testpass
+            - name: TS_PROM_DB_HOST
+              value: timescaledb.tflannag.svc.cluster.local
+            - name: TS_PROM_DB_NAME
+              value: metering
+            - name: TS_PROM_DB_SSL_MODE
+              value: disable
+            - name: TS_PROM_LABELS_CACHE_SIZE
+              value: "1000"
+            - name: TS_PROM_DB_WRITER_CONNECTION_CONCURRENCY
+              value: "1"

--- a/manifests/timescale/exporter/service.yaml
+++ b/manifests/timescale/exporter/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: exporter
+  labels:
+    app: exporter
+spec:
+  selector:
+    app: exporter
+  type: ClusterIP
+  ports:
+    - name: connector-port
+      port: 9201
+      protocol: TCP


### PR DESCRIPTION
Introduces the manifests/ directory, which contains both the timescale-related and requisite monitoring resources in order to utilize the timescale prometheus-postgres exporter in a cluster environment. There isn't much flexibility in these manifests, at least at the moment, as I wasn't using a templating tool like helm or kustomize to help distinguish between different environments locally. There's a bit of overlap in the manifests/timescale/db manifests as I prefer using the Deployment for dev and testing purposes as it's easy to rotate the metering database when I need to as opposed to using the PVC + StatefulSet approach and having to manually clean up those resources myself.

Also adds a real barebone (and hardcoded) helper script for exec-ing into the TimescaleDB instance and opening the `psql` command prompt for the metering database.