### PR TITLE
hack,manifests: Add installation script and introduce README

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -1,0 +1,59 @@
+#! /bin/bash
+
+set -eou pipefail
+
+: "${KUBECONFIG:?}"
+
+ROOT_DIR=$(dirname "${BASH_SOURCE[0]}")/..
+
+export NAMESPACE=${1:-tflannag}
+export MANIFEST_DIR=${MANIFEST_DIR:=${ROOT_DIR}/manifests}
+
+if ! oc get ns ${NAMESPACE} >/dev/null 2>&1; then
+    oc create ns ${NAMESPACE}
+fi
+
+#
+# Create the TimescaleDB resources
+#
+if ! oc -n ${NAMESPACE} get deployment timescaledb >/dev/null 2>&1; then
+    echo "Creating the TimescaleDB Deployment"
+    oc -n ${NAMESPACE} apply -f ${MANIFEST_DIR}/timescale/db/deployment.yaml
+fi
+
+if ! oc -n ${NAMESPACE} get service timescaledb >/dev/null 2>&1; then
+    echo "Creating the TimescaleDB Service"
+    oc -n ${NAMESPACE} apply -f ${MANIFEST_DIR}/timescale/db/service.yaml
+fi
+
+export CLUSTER_IP=$(oc -n ${NAMESPACE} get services/timescaledb -o jsonpath='{.spec.clusterIP}')
+while [[ $? != 0 ]]; do
+    echo "Waiting for the 'timescaledb' Service to have a populated spec.ClusterIP"
+    export CLUSTER_IP=$(oc -n ${NAMESPACE} get services/timescaledb --jsonpath='{.spec.clusterIP}')
+done
+
+#
+# Create the postgres exporter resources
+#
+if ! oc -n ${NAMESPACE} get deployment exporter >/dev/null 2>&1; then
+    echo "Creating the exporter Deployment"
+    envsubst < ${MANIFEST_DIR}/timescale/exporter/deployment.yaml | oc -n ${NAMESPACE} apply -f -
+fi
+
+if ! oc -n ${NAMESPACE} get service exporter >/dev/null 2>&1; then
+    echo "Creating the exporter Service"
+    oc -n ${NAMESPACE} apply -f ${MANIFEST_DIR}/timescale/exporter/service.yaml
+fi
+
+#
+# Create the monitoring resources
+#
+if ! oc -n openshift-monitoring get configmap cluster-monitoring-operator >/dev/null 2>&1; then
+    echo "Creating the cluster-monitoring-operator ConfigMap"
+    envsubst < ${MANIFEST_DIR}/monitoring/configmap.yaml | oc -n openshift-monitoring apply -f -
+fi
+
+if ! oc -n ${NAMESPACE} cluster-monitoring-operator >/dev/null 2>&1; then
+    echo "Creating the metering PrometheusRule custom resource"
+    envsubst < ${MANIFEST_DIR}/monitoring/rules.yaml | oc -n ${NAMESPACE} apply -f -
+fi

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -1,0 +1,18 @@
+# Overview of the manifest/ directory
+
+This directory contains the list of Kubernetes resources needed to deploy a real POC version of the TimescaleDB + Prometheus/Postresql exporter resources.
+
+## General Notes
+
+The `remote_write` configuration only grabs a very small subset of available Prometheus metrics. Note: In the case of Openshift, multiple Prometheus replicas are deployed by default, which can lead to series duplication, which may not be an actual concern if those values eventually average out. My understanding is there's no way to utilize the thanos-querier query interface layer, at least in the current, released versions of the monitoring stack.
+
+Utilizing the PrometheusRules custom resources is highly, highly recommended due to the potentially heavy memory utilization of the exporter. Without scraping metrics that have been pre-computed, which is the case of metrics that are in a particular rule group, you risk the exporter getting evicted from nodes due to an ever expanding heap. Digging into the pprof report locally would suggest that the constant unmarshalling of Prometheus labels is a source of pain points, and the current implementation is preventing objects from being properly garbage collected by Go. In the case you attempt to set memory resource limits on the exporter, you getting into a state where the exporter is consistently reporting an OOMKilled status as kubelet is killing that process whenever the memory consumption has been reached it's configured limit.
+
+Extending the out-of-the-box Postgresql views/available metrics scraped from Prometheus isn't the greatest UX at the moment. In order to do this, you can either update the remote_write configuration in the openshift-cluster-monitoring ConfigMap, or updating the list of Prometheus `metering.rules` rules that get deployed as a part of the monitoring manifest resources.
+
+## Limitations
+
+- The exporter and database containers are deployed separately as Pods. In the future, it makes more sense to have the exporter as a sidecar container in the same Pod as the TimescaleDB database.
+- PVC backs up the entire /var/lib/postgresql/data directory. I've read but haven't really deep dived into whether it's necessary to have a dedicated volume for the WAL records.
+- No general recommendations for resource requests or limits for either of the Pods.
+- When deploying on Openshift, the `anyuid` scc needs to be added to the default ServiceAccount in the namespace those resources are present. There's probably a better workaround for this, like checking what's an appropriate fsGroup configuration, but this will do the trick.

--- a/manifests/monitoring/configmap.yaml
+++ b/manifests/monitoring/configmap.yaml
@@ -7,7 +7,7 @@ data:
   config.yaml: |
     prometheusK8s:
       remoteWrite:
-      - url: "http://exporter.tflannag.svc.cluster.local:9201/write"
+      - url: "http://exporter.$NAMESPACE.svc.cluster.local:9201/write"
         writeRelabelConfigs:
           - sourceLabels: [__name__]
             regex: 'metering:(.*)'

--- a/manifests/monitoring/rules.yaml
+++ b/manifests/monitoring/rules.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: metering
-  namespace: tflannag
+  namespace: $NAMESPACE
 spec:
   groups:
   - interval: 5s

--- a/manifests/timescale/db/deployment.yaml
+++ b/manifests/timescale/db/deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: timescaledb
+  labels:
+    app: timescaledb
 spec:
   replicas: 1
   selector:

--- a/manifests/timescale/exporter/deployment.yaml
+++ b/manifests/timescale/exporter/deployment.yaml
@@ -33,7 +33,7 @@ spec:
             - name: TS_PROM_DB_PASSWORD
               value: testpass
             - name: TS_PROM_DB_HOST
-              value: timescaledb.tflannag.svc.cluster.local
+              value: timescaledb.$NAMESPACE.svc
             - name: TS_PROM_DB_NAME
               value: metering
             - name: TS_PROM_DB_SSL_MODE


### PR DESCRIPTION
These changes are namely follow-ups to the manifests introduced in #2. Instead of pouring time into parameterizing these manifests more, I'm just going to bite the bullet and use something less robust, like `envsubst`, to at least inject a namespace parameter as needed.

In addition to that, I added an initial implementation at a script that aims towards installing all of these resources. Note: this script isn't super flexible in the case where a particular resource already exists, so it won't attempt to reconcile any differences between the rendered manifests and the current resource content.