### PR TITLE
hack: Add the 'anyuid' SCC to the default ServiceAccount

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -10,7 +10,11 @@ export NAMESPACE=${1:-tflannag}
 export MANIFEST_DIR=${MANIFEST_DIR:=${ROOT_DIR}/manifests}
 
 if ! oc get ns ${NAMESPACE} >/dev/null 2>&1; then
+    echo "Creating the ${NAMESPACE} namespace"
     oc create ns ${NAMESPACE}
+    
+    echo "Adding the 'anyuid' SCC to the default ServiceAccount"
+    oc -n ${NAMESPACE} adm policy add-scc-to-user anyuid -z default
 fi
 
 #


### PR DESCRIPTION
When deploying the out-of-the-box TimescaleDB and postgresql container images on Openshift, there are problems with those images requiring root permissions. In the case of the exporter, that code wants to change the permissions on the /var/lib/postgresql/data directory, which results in an `operation not permitted` error being emitted. In order to avoid using my brain, adding the anyuid SCC to whatever namespace gets created will solve those kinds of errors. In the future, should just build these images ourselves to avoid errors like these so we don't have to utilize a workaround like this, or find the appropriate fsGroup configuration.

Note: this change implies that if the namespace already exists, that SCC won't be added, which is fine for my developmental purposes but should be changed in future iterations.