### PR TITLE
hack,manifests: Remove metadata.namespace parameter in the PrometheusRules manifest

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -59,5 +59,5 @@ fi
 
 if ! oc -n ${NAMESPACE} cluster-monitoring-operator >/dev/null 2>&1; then
     echo "Creating the metering PrometheusRule custom resource"
-    envsubst < ${MANIFEST_DIR}/monitoring/rules.yaml | oc -n ${NAMESPACE} apply -f -
+    oc -n ${NAMESPACE} apply -f ${MANIFEST_DIR}/monitoring/rules.yaml
 fi

--- a/manifests/monitoring/rules.yaml
+++ b/manifests/monitoring/rules.yaml
@@ -2,7 +2,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: metering
-  namespace: $NAMESPACE
 spec:
   groups:
   - interval: 5s


### PR DESCRIPTION
There's no need to add a metadata.namespace parameter for this CR manifest as we can just specify a namespace argument using the CLI. With that in mind, we also have no need for utilizing the `envsubst` functionalities at all as there's no templating that needs to be done before creation time.`