### PR TITLE
manifests: Add additional metering Prometheus rules

### DIFF
--- a/manifests/monitoring/rules.yaml
+++ b/manifests/monitoring/rules.yaml
@@ -49,3 +49,9 @@ spec:
     - expr: |
         sum(kube_pod_container_resource_requests_memory_bytes) by (pod, namespace, node)
       record: metering:pod_request_memory_bytes
+    - expr: |
+        sum(rate(container_cpu_usage_seconds_total{container!="POD",container!="",pod!=""}[5m])) BY (pod, namespace, node)
+      record: metering:pod_usage_cpu_cores
+    - expr: |
+        sum(container_memory_usage_bytes) by (pod, namespace, node)
+      record: metering:pod_usage_memory_bytes


### PR DESCRIPTION
Updates the manifest/monitoring/rules.yaml manifest file with rules for Pod CPU and memory usage metrics.