### PR TITLE
manifests: Introduce half-baked Presto coordinator-only setup

### DIFF
--- a/manifests/presto/catalog_configmap.yaml
+++ b/manifests/presto/catalog_configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: catalog
+data:
+  hive.properties: |
+    connector.name=hive-hadoop2
+    hive.metastore=file
+    hive.metastore.catalog.dir=/var/hive/metastore
+
+  prometheus.properties: |
+    connector.name=prometheus
+    prometheus.uri=https://thanos-querier.openshift-monitoring.svc:9091/
+    prometheus.query.chunk.size.duration=1d
+    prometheus.max.query.range.duration=21d
+    prometheus.cache.ttl=30s
+    prometheus.bearer.token.file=/var/run/secrets/kubernetes.io/serviceaccount/token

--- a/manifests/presto/coordinator_configmap.yaml
+++ b/manifests/presto/coordinator_configmap.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config
+data:
+  log.properties: |
+    com.facebook.presto=INFO
+
+  node.properties: |
+    node.data-dir=/var/presto/data
+    node.environment=production
+  
+  config.properties: |
+    coordinator=true
+    node-scheduler.include-coordinator=true
+
+    discovery-server.enabled=true
+    http-server.http.port=8080
+    discovery.uri=http://presto:8080
+    
+    query.max-memory=5GB
+    query.max-memory-per-node=1GB
+    query.max-total-memory-per-node=2GB
+
+  jvm.config: |
+    -server
+    -XX:+UseContainerSupport
+    -XX:+UseG1GC
+    -XX:+UseGCOverheadLimit
+    -XX:InitialRAMPercentage=50.0
+    -XX:MaxRAMPercentage=50.0
+    -XX:+ExplicitGCInvokesConcurrent
+    -XX:+HeapDumpOnOutOfMemoryError
+    -XX:HeapDumpPath=/var/presto/logs/heap_dump.bin
+    -XX:+ExitOnOutOfMemoryError
+    -XX:ErrorFile=/var/presto/logs/java_error%p.log
+    -verbose:gc
+    -Xloggc:/var/presto/logs/gc.log
+    -XX:+PrintGCDetails
+    -javaagent:/opt/jmx_exporter/jmx_exporter.jar=8082:/opt/jmx_exporter/config/config.yml
+    -Dcom.sun.management.jmxremote
+    -Dcom.sun.management.jmxremote.local.only=false
+    -Dcom.sun.management.jmxremote.ssl=false
+    -Dcom.sun.management.jmxremote.authenticate=false
+    -Dcom.sun.management.jmxremote.port=8081
+    -Dcom.sun.management.jmxremote.rmi.port=8081
+    -Djava.rmi.server.hostname=127.0.0.1

--- a/manifests/presto/deployment.yaml
+++ b/manifests/presto/deployment.yaml
@@ -1,0 +1,143 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coordinator
+  labels:
+    app: presto
+    presto: coordinator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: presto
+  template:
+    metadata:
+      labels:
+        app: presto
+        presto: coordinator
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      serviceAccount: presto
+      volumes:
+      - name: config-properties
+        configMap:
+          name: config
+      - name: catalog-properties
+        configMap:
+          name: catalog  
+      - name: jmx-properties
+        configMap:
+          name: jmx
+      - name: trusted-ca-bundle
+        configMap:
+          name: coordinator-trusted-ca-bundle
+          items:
+          - key: ca-bundle.crt
+            path: service-ca.crt
+      - name: presto-data
+        emptyDir: {}
+      - name: presto-logs
+        emptyDir: {}
+      - name: metastore
+        emptyDir: {}
+      - name: presto-etc
+        emptyDir: {}
+      initContainers:
+      - name: setup-coordinator-properties
+        image: quay.io/tflannag/presto:334
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/bash
+        - -c
+        - |
+          #! /bin/bash
+          
+          set -eou pipefail
+
+          echo "Copying ConfigMap volume contents"
+          cp -v -L -r -f /presto-etc/* /opt/presto/presto-server/etc/
+
+          # add node id to node config
+          NODE_CONFIG=/opt/presto/presto-server/etc/node.properties
+          # ensure there's a newline between the last item in the config and what we add
+          echo "" >> $NODE_CONFIG
+          if ! grep -q -F 'node.id' "$NODE_CONFIG"; then
+            NODE_ID="node.id=$MY_NODE_ID"
+            echo "Adding $NODE_ID to $NODE_CONFIG"
+            echo "$NODE_ID" >> "$NODE_CONFIG"
+          fi
+        env:
+        - name: MY_NODE_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        volumeMounts:
+        - name: presto-etc
+          mountPath: /opt/presto/presto-server/etc
+        - name: config-properties
+          mountPath: /presto-etc
+      containers:
+      - name: coordinator
+        image: quay.io/tflannag/presto:334
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/bash
+        - -c
+        - |
+          #! /bin/bash
+          set -euo pipefail
+
+          function importCert() {
+            PEM_FILE=$1
+            PASSWORD=$2
+            KEYSTORE=$3
+            # number of certs in the PEM file
+            CERTS=$(grep 'END CERTIFICATE' $PEM_FILE| wc -l)
+
+            # For every cert in the PEM file, extract it and import into the JKS keystore
+            # awk command: step 1, if line is in the desired cert, print the line
+            #              step 2, increment counter when last line of cert is found
+            for N in $(seq 0 $(($CERTS - 1))); do
+              ALIAS="${PEM_FILE%.*}-$N"
+              cat $PEM_FILE |
+                awk "n==$N { print }; /END CERTIFICATE/ { n++ }" |
+                keytool -noprompt -import -trustcacerts \
+                  -alias $ALIAS -keystore $KEYSTORE -storepass $PASSWORD
+            done
+          }
+
+          # # always add the openshift service-ca.crt if it exists
+          # if [ -a /etc/pki/ca-trust/extracted/pem/service-ca.crt ]; then
+          #   echo "Adding /etc/pki/ca-trust/extracted/pem/service-ca.crt to $JAVA_HOME/lib/security/cacerts"
+          #   importCert /etc/pki/ca-trust/extracted/pem/service-ca.crt changeit $JAVA_HOME/lib/security/cacerts
+          # fi
+
+          echo "Adding /var/run/secrets/kubernetes.io/serviceaccount/ca.crt to $JAVA_HOME/lib/security/cacerts"
+          importCert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt changeit $JAVA_HOME/lib/security/cacerts
+
+          /opt/presto/presto-server/bin/launcher run
+        ports:
+        - name: api
+          containerPort: 8080
+        - name: metrics
+          containerPort: 8082
+        volumeMounts:
+        - name: trusted-ca-bundle
+          mountPath: /etc/pki/ca-trust/extracted/pem
+        - name: presto-etc
+          mountPath: /opt/presto/presto-server/etc
+        - name: catalog-properties
+          mountPath: /opt/presto/presto-server/etc/catalog
+        - name: presto-data
+          mountPath: /var/presto/data
+        - name: presto-logs
+          mountPath: /var/presto/logs
+        - name: jmx-properties
+          mountPath: /opt/jmx_exporter/config
+        - name: metastore
+          mountPath: /var/hive/metastore
+        resources:
+          requests:
+            cpu: 1
+            memory: 1Gi

--- a/manifests/presto/jmx_configmap.yaml
+++ b/manifests/presto/jmx_configmap.yaml
@@ -1,0 +1,81 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jmx
+  labels:
+    app: presto
+data:
+  config.yml: |
+    ---
+    lowercaseOutputName: true
+    lowercaseOutputLabelNames: true
+    attrNameSnakeCase: false
+    rules:
+      # capture percentile and set quantile label
+      - pattern: 'presto.plugin.hive<type=(.+), name=hive><>(.+AllTime).P(\d+): (.*)'
+        name: 'presto_hive_$1_$2_seconds'
+        type: GAUGE
+        valueFactor: 0.001
+        labels:
+          quantile: '0.$3'
+      # match non-percentiles
+      - pattern: 'presto.plugin.hive<type=(.+), name=hive><>(.+AllTime.+): (.*)'
+        name: 'presto_hive_$1_$2_seconds'
+        type: GAUGE
+        valueFactor: 0.001
+        # counts
+      - pattern: 'presto.plugin.hive<type=(.+), name=hive><>(.+TotalCount.*): (.*)'
+        name: 'presto_hive_$1_$2_total'
+        type: COUNTER
+      # capture percentile and set quantile label
+      - pattern: 'presto.plugin.hive.s3<type=(.+), name=hive><>(.+AllTime).P(\d+): (.*)'
+        name: 'presto_hive_s3_$1_$2_seconds'
+        type: GAUGE
+        valueFactor: 0.001
+        labels:
+          quantile: '0.$3'
+      # match non-percentiles
+      - pattern: 'presto.plugin.hive.s3<type=(.+), name=hive><>(.+AllTime.+): (.*)'
+        name: 'presto_hive_s3_$1_$2_seconds'
+        type: GAUGE
+        valueFactor: 0.001
+        # counts
+      - pattern: 'presto.plugin.hive.s3<type=(.+), name=hive><>(.+TotalCount.*): (.*)'
+        name: 'presto_hive_s3_$1_$2_total'
+        type: COUNTER
+      # capture percentile and set quantile label
+      - pattern: 'presto.plugin.hive.metastore.thrift<type=(.+), name=hive><>(.+AllTime).P(\d+): (.*)'
+        name: 'presto_hive_metastore_thrift_$1_$2_seconds'
+        type: GAUGE
+        valueFactor: 0.001
+        labels:
+          quantile: '0.$3'
+      # match non-percentiles
+      - pattern: 'presto.plugin.hive.metastore.thrift<type=(.+), name=hive><>(.+AllTime.+): (.*)'
+        name: 'presto_hive_metastore_thrift_$1_$2_count_seconds'
+        type: GAUGE
+        valueFactor: 0.001
+      # counts
+      - pattern: 'presto.plugin.hive.metastore.thrift<type=(.+), name=hive><>(.+TotalCount.*): (.*)'
+        name: 'presto_hive_metastore_thrift_$1_$2_total'
+        type: COUNTER
+      - pattern: 'presto.execution<name=(.+)><>(.+AllTime).P(\d+): (.*)'
+        name: 'presto_execution_$1_$2_seconds'
+        type: GAUGE
+        valueFactor: 0.001
+        labels:
+          quantile: '0.$3'
+      - pattern: 'presto.execution<name=(.+)><>(.+AllTime.+): (.*)'
+        name: 'presto_execution_$1_$2_seconds'
+        type: GAUGE
+        valueFactor: 0.001
+      # counts
+      - pattern: 'presto.execution<name=(.+)><>(.+TotalCount.*): (.*)'
+        name: 'presto_execution_$1_$2_total'
+        type: COUNTER
+      - pattern: 'presto.memory<type=(.*), name=(.*)><>(.+): (.*)'
+        name: 'presto_memory_$1_$2_$3'
+        type: GAUGE
+      - pattern: 'presto.failuredetector<name=HeartbeatFailureDetector><>ActiveCount: (.*)'
+        name: 'presto_heartbeatdetector_activecount'
+        type: GAUGE

--- a/manifests/presto/service.yaml
+++ b/manifests/presto/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: presto
+  labels:
+    app: presto
+    presto: coordinator
+    component: presto-coordinator
+spec:
+  ports:
+  - name: api
+    port: 8080
+  - name: metrics
+    port: 8082
+  selector:
+    app: presto
+    presto: coordinator

--- a/manifests/presto/serviceaccount.yaml
+++ b/manifests/presto/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: presto
+  labels:
+    app: presto

--- a/manifests/presto/trusted_ca_bundle.yaml
+++ b/manifests/presto/trusted_ca_bundle.yaml
@@ -1,0 +1,7 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: coordinator-trusted-ca-bundle
+  labels:
+    config.openshift.io/inject-trusted-cabundle: 'true'
+    app: presto


### PR DESCRIPTION
Add Kubernetes resources responsible for deploying a coordinator-only Presto installation that uses a file-based Hive metastore and enables the Prometheus connector.

Currently, there's still some authentication problems as either the following message is outputted when attempting to query the default schema tables:

```log
Query 20200923_211423_00000_344jz failed: javax.net.ssl.SSLHandshakeException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
```

Or, the Presto service account token that gets injected by the ServiceAccount controller returns a 403 status code. When exec-ing into that container and curling the thanos-querier endpoint for the `up` query using that token in the authorization header, a non-successful return code is also outputted, which may imply that more RBAC is needed to enable Presto to query Prometheus successfully or I'm missing something more obvious.