### PR TITLE
manifests/presto: Grant permissions to the Presto ServiceAccount to query Prometheus

### DIFF
--- a/manifests/presto/cluster_role_prometheus_auth.yaml
+++ b/manifests/presto/cluster_role_prometheus_auth.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tflannag-presto-service-account
+  labels:
+    app: presto
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: presto-service-account
+  labels:
+    app: presto
+subjects:
+- kind: ServiceAccount
+  name: presto
+  namespace: tflannag
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tflannag-presto-service-account


### PR DESCRIPTION
Adds the necessary RBAC needed for Presto to be able to query the Prometheus API endpoint successfully. Previously, using the service account token that gets mounted into the coordinator Pod by default, resulted in a 403 authentication error. Due to this, I was grabbing the prometheus-k8s ServiceAccount token in the openshift-monitoring namespace and manually mounting that token in a known location, updating the prometheus.properties ConfigMap configuration, and explicitly relaunching the bin/launcher process using a script. Now, I'm able to successfully curl the thanos-querier endpoint using the service account token that gets mounted by the controller after applying these ClusterRole rules and rotating the coordinator Pod. 