### PR TITLE
manifests/timescale: Enable leader election for the Promscale exporter

### DIFF
--- a/manifests/timescale/exporter/deployment.yaml
+++ b/manifests/timescale/exporter/deployment.yaml
@@ -48,6 +48,9 @@ spec:
       - name: exporter
         image: quay.io/tflannag/promscale:latest
         imagePullPolicy: IfNotPresent
+        args:
+        - --leader-election-pg-advisory-lock-id=1
+        - --leader-election-pg-advisory-lock-prometheus-timeout=30s
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
The Promscale exporter exposes a leader election to help guard against multiple Prometheus instances attempting to write duplicate data for scraped targets, which is the case for the default Openshift monitoring stack. If we instead update our exporter deployment, using the available leader election parameters, we can stop processing data in queries for multiple prometheus_replicas_id's and only have a single writer that has access to Postgresql at a time.