### PR TITLE
hack,manifests: Add the 'anyuid' SCC policy to the postgres ServiceAccount

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -16,7 +16,7 @@ if ! oc get ns ${NAMESPACE} >/dev/null 2>&1; then
 fi
 
 echo "Adding the 'anyuid' SCC to the default ServiceAccount"
-oc -n ${NAMESPACE} adm policy add-scc-to-user anyuid -z default
+oc -n ${NAMESPACE} adm policy add-scc-to-user anyuid -z postgres
 
 #
 # Create the TimescaleDB resources

--- a/manifests/timescale/db/deployment.yaml
+++ b/manifests/timescale/db/deployment.yaml
@@ -15,9 +15,6 @@ spec:
         app: timescaledb
     spec:
       serviceAccountName: postgres
-      securityContext:
-        fsGroup: 70
-        runAsUser: 70
       containers:
       - name: postgresql
         image: timescale/timescaledb:latest-pg12


### PR DESCRIPTION
Before we were relying on the default ServiceAccount for all Deployment(s) and to avoid deep diving into what permissions are required, the anyuid SCC policy was added as a workaround. Now, we need to add this SCC policy to the postgres ServiceAccount, and not the default one in the namespace.