### PR TITLE
Dockerfile,hack: Update the path to the Promscale CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openshift/origin-release:golang-1.15 AS builder
 
-WORKDIR /timescale-prometheus
+WORKDIR /promscale
 COPY ./pkg ./pkg
 COPY ./cmd ./cmd
 COPY ./go.mod ./go.mod
@@ -12,7 +12,7 @@ ENV GO111MODULE="on"
 # TODO: do the actual building of the binary in Makefile target
 RUN CGO_ENABLED=0 \
     go build -a --mod=vendor --ldflags '-w' \
-    -o /go/timescale-prometheus ./cmd/timescale-prometheus
+    -o /go/promscale ./cmd/promscale
 
 FROM centos:8
 USER 3001

--- a/hack/get-prometheus-k8s-rules.sh
+++ b/hack/get-prometheus-k8s-rules.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+
+token=$(oc -n openshift-monitoring sa get-token prometheus-k8s)
+host=$(oc -n openshift-monitoring get routes prometheus-k8s -o jsonpath={.spec.host})
+
+curl -k -s -H "Authorization: Bearer $token" https://${host}/api/v1/rules | faq -f json

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -15,8 +15,28 @@ if ! oc get ns ${NAMESPACE} >/dev/null 2>&1; then
     oc create ns ${NAMESPACE}
 fi
 
-echo "Adding the 'anyuid' SCC to the default ServiceAccount"
+echo "Adding the 'anyuid' SCC to the Postgres ServiceAccount"
 oc -n ${NAMESPACE} adm policy add-scc-to-user anyuid -z postgres
+
+
+#
+# General Connector Resources
+#
+if ! oc -n ${NAMESPACE} get sa postgres >/dev/null 2>&1; then
+    echo "Creating the exporter Service"
+    oc -n ${NAMESPACE} apply -f ${MANIFEST_DIR}/timescale/sa.yaml
+fi
+
+if ! oc -n ${NAMESPACE} get role ${NAMESPACE}-service-account >/dev/null 2>&1; then
+    echo "Creating the exporter Service"
+    oc -n ${NAMESPACE} apply -f ${MANIFEST_DIR}/timescale/role.yaml
+fi
+
+if ! oc -n ${NAMESPACE} get rolebinding ${NAMESPACE}-service-account >/dev/null 2>&1; then
+    echo "Creating the exporter Service"
+    oc -n ${NAMESPACE} apply -f ${MANIFEST_DIR}/timescale/role_binding.yaml
+fi
+
 
 #
 # Create the TimescaleDB resources


### PR DESCRIPTION
Fixes the Dockerfile after the repository name has been changed.

Adds a hack script for grabbing the available Prometheus rules from a cluster.

Updates the hack/install.sh bash script to install the requisite RBAC and ServiceAccount resources.