### PR TITLE
Makefile: Add rule validation targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,9 @@ vendor:
 	go mod tidy
 	go mod vendor
 	go mod verify
+
+validate-manifest-rules:
+	tail -n +6 manifests/monitoring/rules.yaml | promtool check rules /dev/stdin
+
+validate-metering-rules:
+	kubectl -n openshift-monitoring get prometheusrules metering -o yaml | faq -f yaml '.spec' | promtool check rules /dev/stdin


### PR DESCRIPTION
This validates the manifests/monitoring/rules.yaml recording rule definition file using the `promtool` binary.

Note: the `promtool check rules` sub-command excepts a filepath but we store this manifest, at least for now, as a
PrometheusRule custom resource, which contains fields like apiVersion, metadata, spec, etc. that promtool doesn't
know how to parse. As a workaround, and this is logic is a bit hardcoded for now, we can only read from the sixth
line in that file until the EOF marker, which solves the problematic parsing errors, in addition to having promtool
read from the /dev/stdin path as it's expecting a filepath and not a string input.

Also, there's probably better ways to achieve similar functionality, but I think I prefer utilizing the /dev/* approach
instead of entertaining something like `promtool check rules <(printf '...' $(tail -n ...))` just for readability sake.